### PR TITLE
Added support for specifying a font output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,43 @@ var app = new EmberApp({
 });
 ```
 
+### Output path
+
+You can change the directory where the fonts are copied to using the following configuration:
+
+```js
+var app = new EmberApp({
+  'ember-font-awesome': {
+    fontsOutput: "/some/dir/"
+  }
+});
+```
+
+This is useful when you change the output paths for your ember app. By default, ember-font-awesome copies the font files to `/dist/fonts`. The addon produces a css file to load the fonts that will be included in the vendor css file and expect to find the fonts at `../fonts`. If the css directory is not at the same level as the fonts directory, the site won't load the fonts.
+
+For example, moving the css directory to `/dist/assets/css` would require the fonts directory to be `/dist/assets/fonts` and the configuration would look like this:
+
+```js
+var app = new EmberApp({
+    outputPaths: {
+        app: {
+            css: {
+                  app: "/assets/css/app-name.css",
+            },
+            js: "/assets/js/app-name.js",
+        },
+
+        vendor: {
+            css: "/assets/css/vendor.css",
+            js: "/assets/js/vendor.js",
+        },
+    },
+    'ember-font-awesome': {
+        fontsOutput: "/assets/fonts"
+    }
+});
+```
+
 ## License
 
 [Public Domain](UNLICENSE)

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = {
       fs.readdirSync(fontsPath).forEach(function(fontFilename){
         target.import(
           path.join(fontsPath, fontFilename),
-          { destDir:'/fonts' }
+          { destDir: options.fontsOutput ? options.fontsOutput : '/fonts' }
         );
       });
     }


### PR DESCRIPTION
By default, ember-font-awesome copies the fonts into `/dist/fonts`. The vendor css file from the output css directory expects to find the fonts at `../fonts` which assumes that the fonts and the css are in different directories at the same level, but if the user changes the `outputPaths` variables, the css file generates a 404.

The patch adds a config variable, `fontsOutput`, that defines the path the fonts will be copied to. If it is not defined, it will default to `/fonts`, as it was before, which will copy the font files to `/dist/fonts/`.

Example config:

```js
var app = new EmberApp({
  'ember-font-awesome': {
    fontsOutput: "/assets/fonts/"
  }
});
```

This will copy the fonts to `/dist/assets/fonts`.

Fixes #94 