### PR TITLE
fix(index.js): enables usage by in-repo-addons and in-repo-engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,25 @@ module.exports = {
   },
 
   included: function(app, parentAddon) {
+
     // Quick fix for add-on nesting
-    // https://github.com/ember-cli/ember-cli/issues/3718
     // https://github.com/aexmachina/ember-cli-sass/blob/v5.3.0/index.js#L73-L75
-    if (typeof app.import !== 'function' && app.app) {
-      this.app = app = app.app;
+    // see: https://github.com/ember-cli/ember-cli/issues/3718
+    while (typeof app.import !== 'function' && (app.app || app.parent)) {
+      app = app.app || app.parent;
+    }
+
+    // if app.import and parentAddon are blank, we're probably being consumed by an in-repo-addon
+    // or engine, for which the "bust through" technique above does not work.
+    if (typeof app.import !== 'function' && !parentAddon) {
+      if (app.registry && app.registry.app) {
+        app = app.registry.app;
+      }
+    }
+
+    if (!parentAddon && typeof app.import !== 'function') {
+      throw new Error('ember-font-awesome is being used within another addon or engine and is' +
+        ' having trouble registering itself to the parent application.');
     }
 
     // https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-88122543


### PR DESCRIPTION
I bumped into this issue when trying to use `ember-font-awesome` with some in-repo-addons and in-repo-engines.  TL;DR is that the typical "app bust" techniques don't seem to work for in-repo addon usage, but I found two work arounds, the first of which seems to work for 90% of cases, and the other which seems to work for older ember-cli.

**app.parent technique (90% fix)** 
```
    while (typeof app.import !== 'function' && (app.app || app.parent)) {
      app = app.app || app.parent;
    }
```

**app.registery.app technique (gets the rest)**
```
    if (typeof app.import !== 'function' && !parentAddon) {
      if (app.registry && app.registry.app) {
        app = app.registry.app;
      }
    }
```