### PR TITLE
Check for fonts already imported

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 'use strict';
 
+var chalk = require('chalk');
 var fs = require('fs');
 var path = require('path');
 
@@ -85,12 +86,41 @@ module.exports = {
 
     // Import all files in the fonts folder when option not defined or enabled
     if (!('includeFontFiles' in options) || options.includeFontFiles) {
-      fs.readdirSync(fontsPath).forEach(function(fontFilename){
-        target.import(
-          path.join(fontsPath, fontFilename),
-          { destDir: options.fontsOutput ? options.fontsOutput : '/fonts' }
-        );
+      // Get all of the font files
+      var fontsToImport = fs.readdirSync(fontsPath);
+      var filesInFonts  = []; // Bucket for filenames already in the fonts folder
+      var fontsSkipped  = []; // Bucket for fonts not imported because they already have been
+
+      // Find files already imported into the fonts folder
+      var fontsFolderPath = options.fontsOutput ? options.fontsOutput : '/fonts';
+      target.otherAssetPaths.forEach(function(asset){
+        if (asset.dest && asset.dest.indexOf(fontsFolderPath) !== -1) {
+          filesInFonts.push(asset.file);
+        }
       });
+
+      // Attempt to import each font, if not already imported
+      fontsToImport.forEach(function(fontFilename){
+        if (filesInFonts.indexOf(fontFilename) > -1) {
+          fontsSkipped.push(fontFilename);
+        } else {
+          target.import(
+            path.join(fontsPath, fontFilename),
+            { destDir: fontsFolderPath }
+          );
+        }
+      });
+
+      // Fonts that had already been imported, so we skipped..
+      if (fontsSkipped.length) {
+        this.ui.writeLine(chalk.red(
+          this.name + ': Fonts already imported into the "/fonts" folder [' + fontsSkipped.join(', ') +
+          '] by another addon or in your ember-cli-build.js, disable the import ' +
+          'from other locations or disable the Font Awesome import by setting ' +
+          '`includeFontFiles:false` for the "' + this.name + '" options in your ember-cli-build.js'
+        ));
+      }
+
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-computed-decorators": "0.2.2"


### PR DESCRIPTION
Supercedes #90

Added logic to check for font files that already have been imported
into the fonts folder, and skip the import if that’s the case (avoiding
an ember-cli error). Also notify the user which files were skipped and
how to fix the duplication, but continue with the build since
everything is technically Ok. This applies to issue #84