### PR TITLE
Update .travis.yml to test on more Ember versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ env:
   - EMBER_TRY_SCENARIO=ember-2.3
   - EMBER_TRY_SCENARIO=ember-2.4
   - EMBER_TRY_SCENARIO=ember-2.5
+  - EMBER_TRY_SCENARIO=ember-2.6
+  - EMBER_TRY_SCENARIO=ember-2.7
+  - EMBER_TRY_SCENARIO=ember-2.8
+  - EMBER_TRY_SCENARIO=ember-2.9
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary


### PR DESCRIPTION
Not sure why we are only testing on 2.3 - 2.5, lets add 2.6-2.9 into the mix?