### PR TITLE
Kill bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 
 # dependencies
 /node_modules
-/bower_components
 
 # misc
 /.sass-cache

--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,13 @@
-/bower_components
 /config/ember-try.js
 /dist
 /tests
 /tmp
 **/.gitkeep
-.bowerrc
 .editorconfig
 .ember-cli
 .gitignore
 .jshintrc
 .watchmanconfig
 .travis.yml
-bower.json
 ember-cli-build.js
 testem.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,7 @@ before_install:
   - "npm install -g npm@^2"
 
 install:
-  - npm install -g bower
   - npm install
-  - bower install
 
 script:
   - ember try $EMBER_TRY_SCENARIO test

--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -4,6 +4,8 @@ import computed from 'ember-computed-decorators';
 import tryMatch from '../utils/try-match';
 import optional from '../utils/optional-decorator';
 
+const { isArray } = Ember;
+
 const FaIconComponent = Ember.Component.extend({
   tagName: 'i',
 
@@ -39,7 +41,7 @@ const FaIconComponent = Ember.Component.extend({
 
   @computed('icon', 'params.[]')
   iconCssClass(icon, params) {
-    icon = icon || params[0];
+    icon = icon || isArray(params) && params[0];
     if (icon) {
       return tryMatch(icon, /^fa-/) ? icon : `fa-${icon}`;
     }

--- a/blueprints/ember-font-awesome/index.js
+++ b/blueprints/ember-font-awesome/index.js
@@ -1,7 +1,0 @@
-module.exports = {
-  normalizeEntityName: function() {},
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('font-awesome', '~4.5.0');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,3 @@
+{
+  "name": "ember-font-awesome"
+}

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,6 @@
 {
   "name": "ember-font-awesome",
   "dependencies": {
-    "ember": "components/ember#canary",
-    "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0",
     "font-awesome": "~4.6.0"
   },
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,4 @@
 {
   "name": "ember-font-awesome",
-  "dependencies": {
-    "font-awesome": "~4.6.0"
-  },
-  "resolutions": {
-    "ember": "canary"
-  }
+  "dependencies": {}
 }

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,0 @@
-{
-  "name": "ember-font-awesome",
-  "dependencies": {}
-}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@
 var chalk = require('chalk');
 var fs = require('fs');
 var path = require('path');
+var Funnel = require('broccoli-funnel');
+var merge = require('broccoli-merge-trees');
+
+var faPath = path.dirname(require.resolve('font-awesome/package.json'));
 
 module.exports = {
   name: 'ember-font-awesome',
@@ -18,6 +22,15 @@ module.exports = {
     if (this.options.babel.optional.indexOf('es7.decorators') === -1) {
       this.options.babel.optional.push('es7.decorators');
     }
+  },
+
+  treeForVendor: function(tree) {
+    var faTree = new Funnel(faPath, {
+      destDir: 'font-awesome',
+      include: ['css/*', 'fonts/*', 'less/*', 'scss/*']
+    });
+
+    return merge([tree, faTree]);
   },
 
   included: function(app, parentAddon) {
@@ -51,11 +64,11 @@ module.exports = {
     target.options = target.options || {}; // Ensures options exists for Scss/Less below
     var options = target.options['ember-font-awesome'] || {};
 
-    var faPath = path.join(target.bowerDirectory, 'font-awesome');
-    var scssPath = path.join(faPath, 'scss');
-    var lessPath = path.join(faPath, 'less');
-    var cssPath = path.join(faPath, 'css');
-    var fontsPath = path.join(faPath, 'fonts');
+    var scssPath = 'vendor/font-awesome/scss';
+    var lessPath = 'vendor/font-awesome/less';
+    var cssPath = 'vendor/font-awesome/css';
+    var fontsPath = 'vendor/font-awesome/fonts';
+    var absoluteFontsPath = path.join(faPath, 'fonts');
 
     // Ensure the font-awesome path is added to the ember-cli-sass addon options
     // (Taking a cue from the Babel options above)
@@ -77,14 +90,6 @@ module.exports = {
       }
     }
 
-    // Make sure font-awesome is available
-    if (!fs.existsSync(faPath)) {
-      throw new Error(
-        this.name + ': font-awesome is not available from bower (' + faPath + '), ' +
-        'install it into your project by running `bower install font-awesome --save`'
-      );
-    }
-
     // Early out if no assets should be imported
     if ('includeFontAwesomeAssets' in options && !options.includeFontAwesomeAssets) {
       return;
@@ -101,7 +106,7 @@ module.exports = {
     // Import all files in the fonts folder when option not defined or enabled
     if (!('includeFontFiles' in options) || options.includeFontFiles) {
       // Get all of the font files
-      var fontsToImport = fs.readdirSync(fontsPath);
+      var fontsToImport = fs.readdirSync(absoluteFontsPath);
       var filesInFonts  = []; // Bucket for filenames already in the fonts folder
       var fontsSkipped  = []; // Bucket for fonts not imported because they already have been
 

--- a/package.json
+++ b/package.json
@@ -18,22 +18,24 @@
   "author": "Marten Schilstra <mail@martenschilstra.nl>",
   "license": "Unlicense",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "^2.0.1",
-    "ember-cli": "2.7.0",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "^2.11.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-qunit": "^2.0.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
+    "ember-load-initializers": "^0.6.3",
     "ember-resolver": "^2.0.3",
+    "ember-source": "^2.11.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [
@@ -42,8 +44,8 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-computed-decorators": "0.2.2"
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-computed-decorators": "^0.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "ember-addon"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^1.2.1",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-computed-decorators": "^0.3.0"
+    "ember-computed-decorators": "^0.3.0",
+    "font-awesome": "^4.7.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
ember-cli is working on phasing out bower.

At our company we're actively working towards that goal and have successfully eradicated all direct bower dependencies of our apps and replaced them with their npm / yarn counter parts.

Next up are indirect bower dependencies, i.e. dependencies introduced by third-party addons.

`ember-font-awesome` is a fantastic addon that we use extensively in all of our apps. :heart: 

This PR updates this addon to the lastest `ember-cli@2.11.0` and imports `font-awesome@^0.4.7` from `node_modules` rather than `bower_components`, thereby removing any and every usage of bower. :tada: :sparkles: 

All configuration parameters still work as expected. All relevant `font-awesome` files are merged into the vendor tree as a `font-awesome` sub-directory. The relevant paths are still added to Less and Sass.

I did not test this with `ember-cli-sass` or `ember-cli-less`, but everything should just continue to work. Vanilla CSS works just fine. 

All tests that passed prior to my changes, still pass. The two failing tests, still fail.

I hope, this PR matches your quality expectations. If there's something wrong, please let me know!