### PR TITLE
Support the ability to exclude specific font types

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,20 @@ var app = new EmberApp({
 });
 ```
 
-In addition, you can configure the addon to _just_ exclude the font file assets by adding
+You can also configure the addon to _only_ import specific font file types by adding
+the following configuration in `ember-cli-build.js`:
+
+**Default:** `*.{eot,svg,ttf,woff,woff2,otf}`
+
+```js
+var app = new EmberApp({
+  'ember-font-awesome': {
+    fontFilePattern: "*.{woff,woff2}"
+  }
+});
+```
+
+In addition, you can configure the addon to exclude the font file assets entirely by adding
 the following configuration in `ember-cli-build.js`:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -246,15 +246,15 @@ var app = new EmberApp({
 });
 ```
 
-You can also configure the addon to _only_ import specific font file types by adding
+You can also configure the addon to _only_ import specific font formats by adding
 the following configuration in `ember-cli-build.js`:
 
-**Default:** `*.{eot,svg,ttf,woff,woff2,otf}`
+**Default:** `['eot', 'svg', 'ttf', 'woff', 'woff2', 'otf']`
 
 ```js
 var app = new EmberApp({
   'ember-font-awesome': {
-    fontFilePattern: "*.{woff,woff2}"
+    fontFormats: ['woff', 'woff2']
   }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -13,9 +13,12 @@ module.exports = {
   name: 'ember-font-awesome',
 
   treeForVendor: function(tree) {
+    // Get configured fontFilePattern
+    let fontFilePattern = this.options.fontFilePattern || "*.{eot,svg,ttf,woff,woff2,otf}";
+    // Funnel required font types
     return new Funnel(faPath, {
       destDir: 'font-awesome',
-      include: ['css/*', 'fonts/*']
+      include: ['css/*', `fonts/${fontFilePattern}`]
     });
   },
 
@@ -49,6 +52,8 @@ module.exports = {
     var target = (parentAddon || app);
     target.options = target.options || {}; // Ensures options exists for Scss/Less below
     var options = target.options['ember-font-awesome'] || {};
+
+    this.options = options;
 
     var scssPath = path.join(faPath, 'scss');
     var lessPath = path.join(faPath, 'less');

--- a/index.js
+++ b/index.js
@@ -13,12 +13,20 @@ module.exports = {
   name: 'ember-font-awesome',
 
   treeForVendor: function(tree) {
-    // Get configured fontFilePattern
-    let fontFilePattern = this.options.fontFilePattern || "*.{eot,svg,ttf,woff,woff2,otf}";
+    // Get configured fontFormats
+    let fontFormats = this.options.fontFormats || ['eot', 'svg', 'ttf', 'woff', 'woff2', 'otf'];
+    let fontFormatsString = fontFormats.join(',');
+    // Define fontFormatPattern
+    let fontFormatPattern;
+    if (fontFormats.length > 1) {
+      fontFormatPattern = `*.{${fontFormatsString}}`;
+    } else {
+      fontFormatPattern = `*.${fontFormatsString}`;
+    }
     // Funnel required font types
     return new Funnel(faPath, {
       destDir: 'font-awesome',
-      include: ['css/*', `fonts/${fontFilePattern}`]
+      include: ['css/*', `fonts/${fontFormatPattern}`]
     });
   },
 

--- a/index.js
+++ b/index.js
@@ -5,14 +5,13 @@ var chalk = require('chalk');
 var fs = require('fs');
 var path = require('path');
 var Funnel = require('broccoli-funnel');
-var merge = require('broccoli-merge-trees');
 
 var faPath = path.dirname(require.resolve('font-awesome/package.json'));
 
 module.exports = {
   name: 'ember-font-awesome',
 
-  treeForVendor: function(tree) {
+  treeForVendor: function() {
     // Get configured fontFormats
     let fontFormats = this.options.fontFormats || ['eot', 'svg', 'ttf', 'woff', 'woff2', 'otf'];
     let fontFormatsString = fontFormats.join(',');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   ],
   "dependencies": {
     "broccoli-funnel": "^1.1.0",
-    "broccoli-merge-trees": "^1.2.1",
     "chalk": "^1.1.3",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",


### PR DESCRIPTION
This PR introduces a new option named `fontFilePattern`, that allows the user to configure which font types they would like to be included in the build output.

Usage is based on the [filePattern](https://github.com/ember-cli-deploy/ember-cli-deploy-s3#filepattern) option used in [ember-cli-deploy-s3](https://github.com/ember-cli-deploy/ember-cli-deploy-s3).

The default value for this option is `*.{eot,svg,ttf,woff,woff2,otf}`, which includes all of the font types supplied by FontAwesome, meaning that the change should be fully backwards compatible.