### PR TITLE
added fallback configuration when using as nested addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
 
   treeForVendor: function() {
     // Get configured fontFormats
+    this.hostBuildOptions = this.hostBuildOptions || {};
     let fontFormats = this.hostBuildOptions.fontFormats || ['eot', 'svg', 'ttf', 'woff', 'woff2', 'otf'];
     let fontFormatsString = fontFormats.join(',');
     // Define fontFormatPattern


### PR DESCRIPTION
I had an issue where the `this.hostBuildOptions` configuration value was missing when I used this addon as a nested addon.  
```
included: function(app, parentAddon) {
    this._super.included.apply(arguments);
}
```
Providing a default empty configuration object if its not found resolved this issue for me.