### PR TITLE
Add some help info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The [Font Awesome examples](http://fortawesome.github.io/Font-Awesome/examples/)
 illustrate the various options and their effects. It should be fairly simple to
 map these options to their `{{fa-icon}}` counterparts.
 
+## :sos: Looking for Help?
+
+- :warning: **Bug reports**: If your bug hasn't been reported yet, please [**open an issue**][new-issue]. Try to pick a short but descriptive title. Make sure you're using the latest version of *ember-font-awesome*. In the issue body, try to provide exact steps for reproduction, ideally with example code. If you can't, please include any and all error messages, as many details as possible and exact information on which Ember.js / ember-cli version and browser / OS you're using.
+- ![Slack Icon](https://i.imgur.com/Bjckhpc.png) **Slack**: We're happy to help you in our [**#e-font-awesome**][slack] Slack channel! You can [create an Ember Community Slack account][slackin] here for free.
+
+
 #### Larger Icons
 
 ```hbs
@@ -324,3 +330,7 @@ var app = new EmberApp({
 ## License
 
 [Public Domain](UNLICENSE)
+
+[slack]: https://embercommunity.slack.com/messages/C6UMSLS74/
+[slackin]: https://ember-community-slackin.herokuapp.com/
+[new-issue]: https://github.com/martndemus/ember-font-awesome/issues/new


### PR DESCRIPTION
Adding some easy links for people to find help.

I stole this from [Ember Light Table](https://github.com/offirgolan/ember-light-table/blob/master/README.md#sos-looking-for-help) because I like theirs and didn't think I could do it better.