### PR TITLE
Update version of ember-ast-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 dist: trusty
 sudo: required

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ statically. There is a few (edge) cases that we had to drop to achieve that:
 - Before this version, you could manually type `<i class="fa fa-some-icon"></i>` and it would work. Now, since
   we use compile-time analysis to remove unused icons from the CSS, the above approach won't work in production. You **have**
   to use the `{{fa-icon}}` helper.
+- It requires node >= 6 (working on making it 4.5+ soon)
 - If you use this addon from within another addon, you have to move it from `devDependencies` to `dependencies` in your `package.json`.
 
 In return you get a an addon with 0 runtime overhead, that ships 0 bytes of javascript code

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -66,17 +66,19 @@
   31. <i aria-hidden="true" class="fa {{if boundValue (concat 'fa-' boundValue)}} fa-pull-{{direction}}"></i>
   ```
 */
-const appendToContent = require('ember-ast-helpers/lib/helpers/append-to-content');
-const buildAttr = require('ember-ast-helpers/lib/helpers/build-attr');
 
-function buildConditional(b, conditionArgs) {
+const appendToContent = require('ember-ast-helpers/dist/lib').appendToContent;
+const buildAttr = require('ember-ast-helpers/dist/lib').buildAttr;
+const b = require('@glimmer/syntax').builders;
+
+function buildConditional(conditionArgs) {
   let args = conditionArgs.map((p) => typeof p === 'string' ? b.string(p) : p);
   return b.mustache(b.path('if'), args);
 }
 
-function buildConcatIfPresent(b, path, concatArgs) {
+function buildConcatIfPresent(path, concatArgs) {
   let args = concatArgs.map((p) => typeof p === 'string' ? b.string(p) : p);
-  return buildConditional(b, [path, b.sexpr(b.path('concat'), args)]);
+  return buildConditional([path, b.sexpr(b.path('concat'), args)]);
 }
 function isDynamic(node) {
   return node.type !== undefined && node.type === 'PathExpression' || node.type === 'SubExpression';
@@ -87,25 +89,24 @@ class AstTransform {
   }
 
   transform(ast) {
-    let b = this.syntax.builders;
     let traverse = this.syntax.traverse;
 
     traverse(ast, {
       BlockStatement: (node) => {
         if (node.path.original === 'fa-list') {
-          return this.transformFaListBlock(b, traverse, node);
+          return this.transformFaListBlock(traverse, node);
         } else if (node.path.original === 'fa-stack') {
-          return this.transformFaStackBlock(b, traverse, node);
+          return this.transformFaStackBlock(traverse, node);
         }
       },
 
       MustacheStatement: (node) => {
         if (node.path.original === 'fa-icon') {
-          return this.transformFaIcon(b, node);
+          return this.transformFaIcon(node);
         } else if (node.path.original === 'fa-list') {
-          return this.buildFaList(b, node);
+          return this.buildFaList(node);
         } else if (node.path.original === 'fa-stack') {
-          return this.buildFaStack(b, node);
+          return this.buildFaStack(node);
         }
       }
     });
@@ -114,12 +115,12 @@ class AstTransform {
   }
 
   // Private functions
-  buildFaList(b, node) {
+  buildFaList(node) {
     let classContent = b.text('fa-ul');
     node.hash.pairs.forEach(function(pair) {
       switch(pair.key) {
         case 'class':
-        classContent = appendToContent(b, pair.value, classContent);
+        classContent = appendToContent(pair.value, classContent);
         break;
       }
     });
@@ -127,22 +128,22 @@ class AstTransform {
     return b.element('ul', [b.attr('class', classContent)], [], children);
   }
 
-  buildFaStack(b, node) {
+  buildFaStack(node) {
     let classContent = b.text('fa-stack');
     node.hash.pairs.forEach(function(pair) {
       switch(pair.key) {
         case 'class':
-          classContent = appendToContent(b, pair.value, classContent);
+          classContent = appendToContent(pair.value, classContent);
           break;
         case 'size':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConcatIfPresent(b, pair.value, ['fa-', pair.value, 'x']), classContent);
+            classContent = appendToContent(buildConcatIfPresent(pair.value, ['fa-', pair.value, 'x']), classContent);
           } else if (pair.value.type === 'NumericLiteral') {
-            classContent = appendToContent(b, `fa-${pair.value.value}x`, classContent);
+            classContent = appendToContent(`fa-${pair.value.value}x`, classContent);
           } else if (isNaN(parseInt(pair.value.value), 10)) {
-            classContent = appendToContent(b, `fa-${pair.value.value}`, classContent);
+            classContent = appendToContent(`fa-${pair.value.value}`, classContent);
           } else {
-            classContent = appendToContent(b, `fa-${pair.value.value}x`, classContent);
+            classContent = appendToContent(`fa-${pair.value.value}x`, classContent);
           }
           break;
       }
@@ -151,37 +152,37 @@ class AstTransform {
     return b.element('span', [b.attr('class', classContent)], [], children);
   }
 
-  transformFaListBlock(b, traverse, node) {
+  transformFaListBlock(traverse, node) {
     let listAlias = node.program.blockParams[0];
 
     traverse(node.program, {
       MustacheStatement: (node) => {
         if (node.path.original === `${listAlias}.fa-icon`) {
-          return this.transformFaIcon(b, node, { listItem: true });
+          return this.transformFaIcon(node, { listItem: true });
         }
       }
     });
 
-    return this.buildFaList(b, node);
+    return this.buildFaList(node);
   }
 
-  transformFaStackBlock(b, traverse, node) {
+  transformFaStackBlock(traverse, node) {
     let listAlias = node.program.blockParams[0];
 
     traverse(node.program, {
       MustacheStatement: (node) => {
         if (node.path.original === `${listAlias}.stack-1x`) {
-          return this.transformFaIcon(b, node, { stack: b.string('1') });
+          return this.transformFaIcon(node, { stack: b.string('1') });
         } else if (node.path.original === `${listAlias}.stack-2x`) {
-          return this.transformFaIcon(b, node, { stack: b.string('2') });
+          return this.transformFaIcon(node, { stack: b.string('2') });
         }
       }
     });
 
-    return this.buildFaStack(b, node);
+    return this.buildFaStack(node);
   }
 
-  transformFaIcon(b, node, opts) {
+  transformFaIcon(node, opts) {
     opts = opts || {};
     let tagName = opts.tagName || 'i';
     let listItem = opts.listItem;
@@ -203,7 +204,7 @@ class AstTransform {
           ariaHidden = pair.value;
           break;
         case 'class':
-          classContent = appendToContent(b, pair.value, classContent);
+          classContent = appendToContent(pair.value, classContent);
           break;
         case 'ariaLabel':
           ariaLabel = pair.value;
@@ -216,9 +217,9 @@ class AstTransform {
           break;
         case 'fixedWidth':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConditional(b, [pair.value, 'fa-fw']), classContent);
+            classContent = appendToContent(buildConditional([pair.value, 'fa-fw']), classContent);
           } else if (pair.value.value) {
-            classContent = appendToContent(b, 'fa-fw', classContent);
+            classContent = appendToContent('fa-fw', classContent);
           }
           break;
         case 'listItem':
@@ -226,124 +227,124 @@ class AstTransform {
           break;
         case 'pulse':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConditional(b, [pair.value, 'fa-pulse']), classContent);
+            classContent = appendToContent(buildConditional([pair.value, 'fa-pulse']), classContent);
           } else if (pair.value.value) {
-            classContent = appendToContent(b, 'fa-pulse', classContent);
+            classContent = appendToContent('fa-pulse', classContent);
           }
           break;
         case 'inverse':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConditional(b, [pair.value, 'fa-inverse']), classContent);
+            classContent = appendToContent(buildConditional([pair.value, 'fa-inverse']), classContent);
           } else if (pair.value.value) {
-            classContent = appendToContent(b, 'fa-inverse', classContent);
+            classContent = appendToContent('fa-inverse', classContent);
           }
           break;
         case 'border':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConditional(b, [pair.value, 'fa-border']), classContent);
+            classContent = appendToContent(buildConditional([pair.value, 'fa-border']), classContent);
           } else if (pair.value.value) {
-            classContent = appendToContent(b, 'fa-border', classContent);
+            classContent = appendToContent('fa-border', classContent);
           }
           break;
         case 'spin':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConditional(b, [pair.value, 'fa-spin']), classContent);
+            classContent = appendToContent(buildConditional([pair.value, 'fa-spin']), classContent);
           } else if (pair.value.value) {
-            classContent = appendToContent(b, 'fa-spin', classContent);
+            classContent = appendToContent('fa-spin', classContent);
           }
           break;
         case 'size':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, buildConcatIfPresent(b, pair.value, ['fa-', pair.value, 'x']), classContent);
+            classContent = appendToContent(buildConcatIfPresent(pair.value, ['fa-', pair.value, 'x']), classContent);
           } else if (pair.value.type === 'NumericLiteral') {
-            classContent = appendToContent(b, `fa-${pair.value.value}x`, classContent);
+            classContent = appendToContent(`fa-${pair.value.value}x`, classContent);
           } else if (isNaN(parseInt(pair.value.value), 10)) {
-            classContent = appendToContent(b, `fa-${pair.value.value}`, classContent);
+            classContent = appendToContent(`fa-${pair.value.value}`, classContent);
           } else {
-            classContent = appendToContent(b, `fa-${pair.value.value}x`, classContent);
+            classContent = appendToContent(`fa-${pair.value.value}x`, classContent);
           }
           break;
         case 'pull':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, 'fa-pull-', classContent);
-            classContent = appendToContent(b, pair.value, classContent, { prependSpace: false });
+            classContent = appendToContent('fa-pull-', classContent);
+            classContent = appendToContent(pair.value, classContent, { prependSpace: false });
           } else {
-            classContent = appendToContent(b, `fa-pull-${pair.value.value}`, classContent);
+            classContent = appendToContent(`fa-pull-${pair.value.value}`, classContent);
           }
           break;
         case 'flip':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, 'fa-flip-', classContent);
-            classContent = appendToContent(b, pair.value, classContent, { prependSpace: false });
+            classContent = appendToContent('fa-flip-', classContent);
+            classContent = appendToContent(pair.value, classContent, { prependSpace: false });
           } else {
-            classContent = appendToContent(b, `fa-flip-${pair.value.value}`, classContent);
+            classContent = appendToContent(`fa-flip-${pair.value.value}`, classContent);
           }
           break;
         case 'rotate':
           if (isDynamic(pair.value)) {
-            classContent = appendToContent(b, 'fa-rotate-', classContent);
-            classContent = appendToContent(b, pair.value, classContent, { prependSpace: false });
+            classContent = appendToContent('fa-rotate-', classContent);
+            classContent = appendToContent(pair.value, classContent, { prependSpace: false });
           } else {
-            classContent = appendToContent(b, `fa-rotate-${pair.value.value}`, classContent);
+            classContent = appendToContent(`fa-rotate-${pair.value.value}`, classContent);
           }
           break;
         case 'color':
           if (isDynamic(pair.value)) {
-            let content = buildConcatIfPresent(b, pair.value, ['color:', pair.value]);
-            attrs.push(buildAttr(b, 'style', content));
+            let content = buildConcatIfPresent(pair.value, ['color:', pair.value]);
+            attrs.push(buildAttr('style', content));
           } else {
-            attrs.push(buildAttr(b, 'style', b.text(`color:${pair.value.value}`)));
+            attrs.push(buildAttr('style', b.text(`color:${pair.value.value}`)));
           }
           break;
         case 'stack':
           stack = pair.value;
           break;
         case 'click':
-          attrs.push(buildAttr(b, 'onclick', pair.value));
+          attrs.push(buildAttr('onclick', pair.value));
           break;
         default:
           console.warn(`{{fa-icon}}: Ignored unknown option named "${pair.key}"`);
       }
     });
     if (ariaHidden === true || ariaHidden.value === true) {
-      attrs.push(buildAttr(b, 'aria-hidden', b.text('true')));
+      attrs.push(buildAttr('aria-hidden', b.text('true')));
     }
     if (ariaLabel) {
-      attrs.push(buildAttr(b, 'aria-label', ariaLabel));
+      attrs.push(buildAttr('aria-label', ariaLabel));
     }
     if (title) {
-      attrs.push(buildAttr(b, 'title', title));
+      attrs.push(buildAttr('title', title));
     }
     if (iconValue) {
       if (isDynamic(iconValue)) {
-        classContent = appendToContent(b, buildConcatIfPresent(b, iconValue, ['fa-', iconValue]), classContent);
+        classContent = appendToContent(buildConcatIfPresent(iconValue, ['fa-', iconValue]), classContent);
         this.addon.fontAwesomeUsage.usedIconsUnknown = true;
       } else {
         if (!this.addon.fontAwesomeUsage.usedIconsUnknown) {
           this.addon.fontAwesomeUsage.usedIcons.add(iconValue.value);
         }
-        classContent = appendToContent(b, `fa-${iconValue.value}`, classContent);
+        classContent = appendToContent(`fa-${iconValue.value}`, classContent);
       }
     }
     if (listItem) {
       if (isDynamic(listItem)) {
-        classContent = appendToContent(b, buildConditional(b, [listItem, 'fa-li']), classContent);
+        classContent = appendToContent(buildConditional([listItem, 'fa-li']), classContent);
       } else {
-        classContent = appendToContent(b, 'fa-li', classContent);
+        classContent = appendToContent('fa-li', classContent);
       }
     }
     if (stack) {
       if (isDynamic(iconValue)) {
-        classContent = appendToContent(b, 'fa-stack-', classContent);
-        classContent = appendToContent(b, stack, classContent, { prependSpace: false });
-        classContent = appendToContent(b, 'x', classContent, { prependSpace: false });
+        classContent = appendToContent('fa-stack-', classContent);
+        classContent = appendToContent(stack, classContent, { prependSpace: false });
+        classContent = appendToContent('x', classContent, { prependSpace: false });
       } else if (stack.value[stack.value.length - 1] !== 'x') {
-        classContent = appendToContent(b, `fa-stack-${stack.value}x`, classContent);
+        classContent = appendToContent(`fa-stack-${stack.value}x`, classContent);
       } else {
-        classContent = appendToContent(b, `fa-stack-${stack.value}`, classContent);
+        classContent = appendToContent(`fa-stack-${stack.value}`, classContent);
       }
     }
-    attrs.push(buildAttr(b, 'class', classContent));
+    attrs.push(buildAttr('class', classContent));
     return b.element(tagName, attrs)
   }
 }

--- a/lib/ast-transform.js
+++ b/lib/ast-transform.js
@@ -67,8 +67,8 @@
   ```
 */
 
-const appendToContent = require('ember-ast-helpers/dist/lib').appendToContent;
-const buildAttr = require('ember-ast-helpers/dist/lib').buildAttr;
+const appendToContent = require('ember-ast-helpers').appendToContent;
+const buildAttr = require('ember-ast-helpers').buildAttr;
 const b = require('@glimmer/syntax').builders;
 
 function buildConditional(conditionArgs) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "broccoli-filter": "^1.2.4",
     "broccoli-funnel": "^1.2.0",
     "chalk": "^1.1.3",
-    "ember-ast-helpers": "0.1.0",
+    "ember-ast-helpers": "0.1.1",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.2",
     "font-awesome": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "broccoli-filter": "^1.2.4",
     "broccoli-funnel": "^1.2.0",
     "chalk": "^1.1.3",
-    "ember-ast-helpers": "0.0.5",
+    "ember-ast-helpers": "0.1.0",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.2",
     "font-awesome": "^4.7.0",
@@ -50,7 +50,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": ">=6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,9 +1878,9 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-ast-helpers@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-ast-helpers/-/ember-ast-helpers-0.1.0.tgz#4feab25cda93af1e8d4e7f63b65f28f7416a8931"
+ember-ast-helpers@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ember-ast-helpers/-/ember-ast-helpers-0.1.1.tgz#df93f6f4ac772bbb68a9a48a8e4b0b1140eac0a3"
   dependencies:
     "@glimmer/compiler" "^0.27.0"
     "@glimmer/syntax" "^0.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,9 +1878,9 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-ast-helpers@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/ember-ast-helpers/-/ember-ast-helpers-0.0.5.tgz#0c11e9093a33b4409db8d500c80f1f6d87212b4a"
+ember-ast-helpers@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-ast-helpers/-/ember-ast-helpers-0.1.0.tgz#4feab25cda93af1e8d4e7f63b65f28f7416a8931"
   dependencies:
     "@glimmer/compiler" "^0.27.0"
     "@glimmer/syntax" "^0.27.0"


### PR DESCRIPTION
I've rebuilt the library from scratch in typescript. It's nicer, more correct and probably even faster.
But it requires node6 again. I'll work in the node4 support once I think the features are stabilised.