### PR TITLE
Allow icons to be included statically

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ statically. There is a few (edge) cases that we had to drop to achieve that:
 - Previously both `{{fa-icon "credit-card"}}` and `{{fa-icon "fa-credit-card"}}` were valid invocations. Now only the first one is. You should not include the `fa-` prefix on the icon names.
 - Previously both `{{fa-icon size="2"}}` and `{{fa-icon size="2x"}}` were valid sizes. Now only the first one is, you cannot pass a string ending in `x`.
 - It requires a Glimmer2 version of Ember (2.10 or bigger)
-- Before this version, you could manually type `<i class="fa fa-some-icon"></i>` and it would work. Now, since
-  we use compile-time analysis to remove unused icons from the CSS, the above approach won't work in production. You **have**
-  to use the `{{fa-icon}}` helper.
 - **It requires node >= 6** (working on making it 4.5+ soon)
 - If you use this addon from within another addon, you have to move it from `devDependencies` to `dependencies` in your `package.json`.
 
@@ -308,6 +305,19 @@ the following configuration in `ember-cli-build.js`:
 var app = new EmberApp({
   'ember-font-awesome': {
     includeFontFiles: false
+  }
+});
+```
+
+### Including specific icons
+
+This addon will strip out unused icons which are not used in your app. If you
+want to use `<i class="fa fa-sort"></i>` you can  force the inclusion of specific icons by adding the following configuration in `ember-cli-build.js`:
+
+```js
+var app = new EmberApp({
+  'ember-font-awesome': {
+    includeStaticIcons: ['sort'],
   }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -110,6 +110,16 @@ module.exports = {
       }
     }
 
+    // Force inclusion of some icons that would otherwise by removed in post processing
+    if ('includeStaticIcons' in options && options.includeStaticIcons.length) {
+      options.includeStaticIcons.forEach(icon => {
+        if (icon.indexOf('fa-') !== -1) {
+          icon = icon.substring(3);
+        }
+        this.fontAwesomeUsage.usedIcons.add(icon);
+      });
+    }
+
     // Early out if no assets should be imported
     if ('includeFontAwesomeAssets' in options && !options.includeFontAwesomeAssets) {
       return;
@@ -131,7 +141,7 @@ module.exports = {
       let fontsSkipped  = []; // Bucket for fonts not imported because they already have been
 
       // Find files already imported into the fonts folder
-      let fontsFolderPath = options.fontsOutput ? options.fontsOutput : '/fonts';      
+      let fontsFolderPath = options.fontsOutput ? options.fontsOutput : '/fonts';
       (target.otherAssetPaths || []).forEach(function(asset){
         if (asset.dest && asset.dest.indexOf(fontsFolderPath) !== -1) {
           filesInFonts.push(asset.file);


### PR DESCRIPTION
Creates an option `includeStaticIcons` to force icons to be included even
if they are not used in our component. This is useful when icons are
needed outside the helpers (such as for inclusion by another addon).

Fixes #161