### PR TITLE
fixes severe IE bug in deprecations check

### DIFF
--- a/addon/components/fa-icon.js
+++ b/addon/components/fa-icon.js
@@ -118,7 +118,7 @@ const FaIconComponent = Ember.Component.extend({
 
     const iconOrParam = icon || isArray(params) && params[0];
     if (iconOrParam) {
-      if (iconOrParam.startsWith('fa-')) {
+      if (iconOrParam.startsWith && iconOrParam.startsWith('fa-')) {
         const preferedIcon = iconOrParam.substring(3);
         deprecate(
           `Passing the icon prefixed with 'fa-' (${iconOrParam}) is deprecated and will be removed in v4. Use '${preferedIcon}' instead.`,
@@ -129,7 +129,7 @@ const FaIconComponent = Ember.Component.extend({
     }
 
     const size = getWithDefault(this, 'size', '').toString();
-    if (size.endsWith('x')) {
+    if (size.endsWith && size.endsWith('x')) {
       const preferedSize = size.substring(0, size.length - 1);
       deprecate(
         `Passing 'size' as '${size}' to fa-icon is deprecated and will be removed in v4. Use size='${preferedSize}' instead`,


### PR DESCRIPTION
`checkDeprecations` introduced a severe IE bug, which stopped the entire app from working in IE when you used the `{{fa-icon ...}}` component. Not sure why `startsWith` and `endsWith` is not properly transpiled, but this simple condition resolves the issue (but does not show the deprecation warning in case somebody is developing Ember apps with Internet Explorer).