### PR TITLE
Add warning about removing unused icons

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,13 @@ module.exports = {
     if (!this.fontAwesomeConfig.hasOwnProperty('removeUnusedIcons')) {
       this.fontAwesomeConfig.removeUnusedIcons = false; // this.app.env === 'production';
     }
+    if (this.fontAwesomeConfig.removeUnusedIcons) {
+      this.ui.writeLine(chalk.yellow(`
+        ${this.name}: Removing unused icons is still experimental and not recommended
+        in any production environment. Take this warning seriously. Test your
+        application before enabling this feature and report any bugs.
+      `));
+    }
 
     let scssPath = path.join(faPath, 'scss');
     let lessPath = path.join(faPath, 'less');


### PR DESCRIPTION
I'm hoping to unlock a final v4 release. There are still reported issues with the icon removal features, however the AST transform has a lot of benefit and it would be nice to get it out there.