### PR TITLE
bump ember decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/argument": "ember-decorators/argument",
+    "@ember-decorators/argument": "^0.8.13",
     "@ember-decorators/babel-transforms": "^0.1.1",
     "broccoli-filter": "^1.2.4",
     "broccoli-funnel": "^2.0.1",


### PR DESCRIPTION
This fixes some #206 but also fixes a dependency issue in ember-popper which ember-bootstrap uses. 

For anyone using the latest ember-cli, ember-font-awesome, and ember-bootstrap, this is an issue.